### PR TITLE
Add a guide for connecting AI agents to the Umami API

### DIFF
--- a/content/docs/guides/connecting-agents.mdx
+++ b/content/docs/guides/connecting-agents.mdx
@@ -22,16 +22,14 @@ HTTP requests to the API without leaking any secrets to prompts.
 
 ## 2. Generate and Configure the API Token
 
-1. Follow the [authentication docs](../api/authentication) to obtain an API token or key.
-2. Point Latchkey to your instance, for example:
+1. Follow the [authentication docs](../api/authentication) to obtain an API token or an API key.
+2. If you don't use Umami Cloud, point Latchkey to your instance. For example:
 
     ```bash
     latchkey services register my-umami \
         --service-family umami \
-        --base-api-url=http://203.0.113.1:8000/api/v1
+        --base-api-url=http://203.0.113.1:3000/api/
     ```
-
-    (This step is not necessary for Umami Cloud.)
 
 3. Insert the API token:
 
@@ -39,9 +37,16 @@ HTTP requests to the API without leaking any secrets to prompts.
     latchkey auth set my-umami -H "Authorization: Bearer <your_token>"
     ```
 
+    Alternatively, for Umami Cloud:
+
+    ```bash
+    latchkey auth set umami -H "x-umami-api-key: <your_api_key>"
+    ```
+
+
 ## 3. Configure the AI Agent
 
-Using `skills.sh`:
+Using [skills.sh](https://skills.sh/):
 
 ```bash
 npx skills add imbue-ai/latchkey
@@ -68,7 +73,7 @@ or
 
 > What does my audience look like on weekends vs. weekdays?
 
-or even just
+or even
 
 > Tell me what's working on our blog and what isn't.
 

--- a/content/docs/guides/connecting-agents.mdx
+++ b/content/docs/guides/connecting-agents.mdx
@@ -1,0 +1,75 @@
+---
+title: Connecting AI agents
+---
+
+# Connect AI Agents to the Umami API
+
+If you'd like to connect an AI agent to the Umami API, for example to help you analyze the events, this guide shows you how.
+
+
+## 1. Install the Prerequisites
+
+On the machine where the agent will run, we'll install the
+Latchkey tool. That will allow the agent to send authenticated
+HTTP requests to the API without leaking any secrets to prompts.
+
+1. Make sure your system has a working `node` installation. If not, you can download it from the [official page](https://nodejs.org/en/download).
+2. Install Latchkey:
+
+    ```bash
+    npm install -g latchkey
+    ```
+
+## 2. Generate and Configure the API Token
+
+1. Follow the [authentication docs](../api/authentication) to obtain an API token or key.
+2. Point Latchkey to your instance, for example:
+
+    ```bash
+    latchkey services register my-umami \
+        --service-family umami \
+        --base-api-url=http://203.0.113.1:8000/api/v1
+    ```
+
+    (This step is not necessary for Umami Cloud.)
+
+3. Insert the API token:
+
+    ```bash
+    latchkey auth set my-umami -H "Authorization: Bearer <your_token>"
+    ```
+
+## 3. Configure the AI Agent
+
+Using `skills.sh`:
+
+```bash
+npx skills add imbue-ai/latchkey
+```
+
+You can also configure the AI agent manually. The exact steps
+will differ depending on the agent. Taking OpenCode as an example:
+
+```bash
+mkdir -p ~/.opencode/skills/latchkey
+latchkey skill-md > ~/.opencode/skills/latchkey/SKILL.md
+```
+
+
+## 4. Use the AI Agent
+
+After completing the previous steps, you should now be able to
+use your AI agent of choice to work with Umami! Here are some
+example questions and tasks for the agent:
+
+> Which referrer sends the highest-quality traffic (with the highest average session duration)?
+
+or
+
+> What does my audience look like on weekends vs. weekdays?
+
+or even just
+
+> Tell me what's working on our blog and what isn't.
+
+From here, it's up to your imagination.

--- a/content/docs/guides/connecting-agents.mdx
+++ b/content/docs/guides/connecting-agents.mdx
@@ -1,8 +1,6 @@
 ---
-title: Connecting AI agents
+title: Connecting AI agents to the API
 ---
-
-# Connect AI Agents to the Umami API
 
 If you'd like to connect an AI agent to the Umami API, for example to help you analyze the events, this guide shows you how.
 

--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -25,7 +25,9 @@
     "running-on-railway",
     "running-on-sevalla",
     "running-on-supabase",
-    "running-on-vercel"
+    "running-on-vercel",
+    "---AI---",
+    "connecting-agents"
   ],
   "defaultOpen": true
 }


### PR DESCRIPTION
This PR adds a simple guide for connecting AI agents to the Umami API.

I believe there are strong use cases for doing so: AI Agents can help the user analyze events, transform stats, or spot patterns in the data.

This could be achieved in various ways. The one that's been chosen here is relatively straightforward, secure (secrets are encrypted, the agents don't see them, no intermediaries or third parties get to see them, either), general (the same setup can be used for any AI agent and even reused for other APIs) and friendly to local setups.