### PR TITLE
Fix wrong header name from CF-RegionCode to CF-Region-Code

### DIFF
--- a/content/docs/(configuration)/enable-cloudflare-headers.mdx
+++ b/content/docs/(configuration)/enable-cloudflare-headers.mdx
@@ -20,7 +20,7 @@ configure Cloudflare to send additional headers.
 Then, you'll have to proxy [the following headers](https://github.com/umami-software/umami/blob/aaa1f9dc58feafe6af54248c5f0611112786fddf/src/lib/detect.ts#L14C2-L18C5) to Umami:
 
 - `CF-IPCountry`
-- `CF-RegionCode`
+- `CF-Region-Code`
 - `CF-IPCity`
 
 For example, if you're using Nginx as a reverse proxy, you can add the following configuration:
@@ -33,7 +33,7 @@ location / {
     proxy_set_header X-Forwarded-Host $host;
     proxy_set_header CF-Connecting-IP $remote_addr;
     proxy_set_header CF-IPCountry $http_cf_ipcountry;
-    proxy_set_header CF-RegionCode $http_cf_regioncode;
+    proxy_set_header CF-Region-Code $http_cf_regioncode;
     proxy_set_header CF-IPCity $http_cf_ipcity;
     proxy_pass http://127.0.0.1:3000;
 }


### PR DESCRIPTION
https://github.com/umami-software/umami/blob/aaa1f9dc58feafe6af54248c5f0611112786fddf/src/lib/detect.ts#L14C2-L18C5

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/docs/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782469066&installation_id=134563449&pr_number=26&repository=umami-software%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fdocs%2Fpull%2F26&signature=0f500a805280bd5be744da11ea378bc8048537c1e4e49d78e5555e3cd4464c61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->