### PR TITLE
Add Running on PikaPods hosting guide

### DIFF
--- a/content/docs/guides/meta.json
+++ b/content/docs/guides/meta.json
@@ -31,6 +31,7 @@
     "running-on-neon",
     "running-on-netlify",
     "running-on-nodion",
+    "running-on-pikapods",
     "running-on-planetscale",
     "running-on-qovery",
     "running-on-railway",

--- a/content/docs/guides/running-on-pikapods.mdx
+++ b/content/docs/guides/running-on-pikapods.mdx
@@ -1,0 +1,33 @@
+---
+title: Running on PikaPods
+---
+
+[PikaPods](https://www.pikapods.com/) is a managed hosting platform that lets you run Umami and 100+ other
+open source apps with a single click — no server setup, Docker, or database configuration required.
+Deployments are fully managed: PikaPods handles updates, backups, and TLS certificates, and you only pay
+for the resources your pod actually uses.
+
+Pricing for Umami starts at around $2.8/month for the smallest instance, and you can resize your pod at
+any time as your traffic grows.
+
+## 1-Click Deploy Button
+
+[![Run on PikaPods](https://www.pikapods.com/static/run-button.svg)](https://www.pikapods.com/pods?run=umami)
+
+### Setup Instructions
+
+[#setup-instructions](#setup-instructions)
+
+1. Create a free account on [PikaPods](https://www.pikapods.com/register). No credit card is required, and new accounts start with $5 in free credit to try things out.
+2. Click the **Run on PikaPods** button above, or search for **Umami** from the
+[available apps](https://www.pikapods.com/apps) page and click **Run Your Own**.
+3. Choose a region and the amount of CPU, RAM, and storage for your pod, then click **Add Pod**.
+4. PikaPods provisions Umami along with its PostgreSQL database automatically and gives you a
+`*.pikapods.com` subdomain — no manual database setup needed.
+5. Once the pod status changes to **Running**, open it and log in with the default `admin` / `umami`
+credentials, then change the password immediately.
+6. Optionally, attach your own domain from the pod's **Settings** tab; PikaPods issues and renews the
+TLS certificate for you.
+
+Need to check resource usage, add a custom domain later, or access your database directly? See PikaPods'
+[pod management docs](https://docs.pikapods.com/manage/) for more.


### PR DESCRIPTION
PikaPods offers 1-click deployment for Umami. It is a trusted hosting service provider for over one hundred self-hosted open source software.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/umami-software/codesmith/docs/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789120366&installation_model_id=22160&pr_number=30&repository=umami-software%2Fdocs&return_to=https%3A%2F%2Fgithub.com%2Fumami-software%2Fdocs%2Fpull%2F30&signature=8c494afec8f1fc38c0813ef03bd6eee44451f5cd2a0bb8c8b6982966487de694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->